### PR TITLE
Add a missing line of documentation

### DIFF
--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -35,6 +35,7 @@ Strophe.addConnectionPlugin 'muc'
   specified chat room.
   (Function) pres_handler_cb - The function call back to handle presence
   in the chat room.
+  (Function) roster_cb - The function call to handle roster info in the chat room
   (String) password - The optional password to use. (password protected
   rooms only)
   ###

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -37,6 +37,7 @@ Strophe.addConnectionPlugin('muc', {
   specified chat room.
   (Function) pres_handler_cb - The function call back to handle presence
   in the chat room.
+  (Function) roster_cb - The function call to handle roster info in the chat room
   (String) password - The optional password to use. (password protected
   rooms only)
   */


### PR DESCRIPTION
There was a missing line of documentation detailing the arguments to the `join(...)` function.
