### PR TITLE
Extended presence support in MUC

### DIFF
--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -38,6 +38,8 @@ Strophe.addConnectionPlugin 'muc'
   (Function) roster_cb - The function call to handle roster info in the chat room
   (String) password - The optional password to use. (password protected
   rooms only)
+  (Object) history_attrs - Optional attributes for retrieving history
+  (XML DOM Element) extended_presence - Optional XML for extending presence
   ###
   join: (room, nick, msg_handler_cb, pres_handler_cb, roster_cb, password, history_attrs) ->
     room_nick = @test_append_nick(room, nick)
@@ -47,10 +49,13 @@ Strophe.addConnectionPlugin 'muc'
     .c("x", xmlns: Strophe.NS.MUC)
 
     if history_attrs?
-      msg = msg.c("history", history_attrs)
+      msg = msg.c("history", history_attrs).up
 
     if password?
       msg.cnode Strophe.xmlElement("password", [], password)
+
+    if extended_presence?
+      msg.up.cnode extended_presence
 
     # One handler for all rooms that dispatches to room callbacks
     @_muc_handler ?=  @_connection.addHandler (stanza) =>

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -40,9 +40,11 @@ Strophe.addConnectionPlugin('muc', {
   (Function) roster_cb - The function call to handle roster info in the chat room
   (String) password - The optional password to use. (password protected
   rooms only)
+  (Object) history_attrs - Optional attributes for retrieving history
+  (XML DOM Element) extended_presence - Optional XML for extending presence
   */
 
-  join: function(room, nick, msg_handler_cb, pres_handler_cb, roster_cb, password, history_attrs) {
+  join: function(room, nick, msg_handler_cb, pres_handler_cb, roster_cb, password, history_attrs, extended_presence) {
     var msg, room_nick, _ref,
       _this = this;
     room_nick = this.test_append_nick(room, nick);
@@ -53,10 +55,13 @@ Strophe.addConnectionPlugin('muc', {
       xmlns: Strophe.NS.MUC
     });
     if (history_attrs != null) {
-      msg = msg.c("history", history_attrs);
+      msg = msg.c("history", history_attrs).up();
     }
     if (password != null) {
       msg.cnode(Strophe.xmlElement("password", [], password));
+    }
+    if (extended_presence != null) {
+      msg.up().cnode(extended_presence);
     }
     if ((_ref = this._muc_handler) == null) {
       this._muc_handler = this._connection.addHandler(function(stanza) {


### PR DESCRIPTION
Fixing a bug where adding both history_attrs and password would result in single node.
Adding a support for extended presence on room join. The resulting stanza looks like this:

``` xml
<presence from='jid@xmpp/resource' to='room@muc/nick'>
  <x xmlns='http://jabber.org/protocol/muc'>
    <history %optional attrs% />
    <password>%optional%</password>
  </x>
  <extended_presence>
    <useful_data1>John</useful_data1>
    <useful_data2>Doe</useful_data2>
  </extended_presence>
</presence>
```

Application is responsible for creating extended presence XML.
