### PR TITLE
Fix html message attachment to `muc` message.

### DIFF
--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -164,7 +164,7 @@ Strophe.addConnectionPlugin 'muc',
     if html_message?
       msg.c("html", xmlns: Strophe.NS.XHTML_IM)
       .c("body", xmlns: Strophe.NS.XHTML)
-      .t(html_message)
+      .h(html_message)
       if msg.node.childNodes.length is 0
         # html creation or import failed somewhere; fallback to plaintext
         parent = msg.node.parentNode

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -187,7 +187,7 @@
           xmlns: Strophe.NS.XHTML_IM
         }).c("body", {
           xmlns: Strophe.NS.XHTML
-        }).t(html_message);
+        }).h(html_message);
         if (msg.node.childNodes.length === 0) {
           parent = msg.node.parentNode;
           msg.up().up();


### PR DESCRIPTION
Pull request [#26](https://github.com/metajack/strophejs-plugins/pull/26/files) for fixing the XHTML support used `.h()` for attaching HTML message part.
Without it, it doesn't work.

Might be that you'd need to regenerate the .js file. I don't use CoffeeScript at all, therefore I just changed both sources.
