### PR TITLE
onMessage should return true

### DIFF
--- a/mam/README.markdown
+++ b/mam/README.markdown
@@ -43,6 +43,7 @@ To query, for example, your personal archive for conversations with
       onMessage: function(message) {
 				console.log("Message from ", $(message).find("forwarded message").attr("from"),
 					": ", $(message).find("forwarded message body").text());
+				return true;
       },
       onComplete: function(response) {
 				console.log("Got all the messages");


### PR DESCRIPTION
Return true to prevent onMessage callback from getting removed. It should be called for each message received, not just for the first one.
