### PR TITLE
X-data-forms in In-Band-registration, no stream feature check there

### DIFF
--- a/register/README.markdown
+++ b/register/README.markdown
@@ -47,6 +47,8 @@ var callback = function (status) {
         connection.authenticate();
     } else if (status === Strophe.Status.CONFLICT) {
         console.log("Contact already existed!");
+    } else if (status === Strophe.Status.REGISTERTIMEOUT) {
+        console.log("Registration form submission timed out.")
     } else if (status === Strophe.Status.NOTACCEPTABLE) {
         console.log("Registration form not properly filled out.")
     } else if (status === Strophe.Status.REGIFAIL) {

--- a/register/strophe.register.js
+++ b/register/strophe.register.js
@@ -427,12 +427,11 @@ Strophe.addConnectionPlugin('register', {
                 }
             ).c(
                 'value',
-                {},
-                value
-            );
+                {}
+            ).t(value);
 
             // Make <x> element current again:
-            submission.up();
+            submission.up().up();
         }
 
         return submission;

--- a/register/strophe.register.js
+++ b/register/strophe.register.js
@@ -195,11 +195,6 @@ Strophe.addConnectionPlugin('register', {
             return;
         }
 
-        if (register.length === 0) {
-            conn._changeConnectStatus(Strophe.Status.REGIFAIL, null);
-            return;
-        }
-
         // send a get request for registration, to get all required data fields
         conn._addSysHandler(this._get_register_cb.bind(this),
                             null, "iq", null, null);


### PR DESCRIPTION
When doing an in-band registration, the XMPP server sends a form to the client, which it has to fill in and return. That form can be sent in two formats: legacy and X-Data (as specified in XEP-0004). The latter one is the preferred format.

Before this pull request, the plugin only supports legacy forms. After it, X-Data forms are also supported, at least to a certain degree (only field types "text-single", "text-private" and "hidden"). 

Also, there was a check if the server stream advertised support for in-band registration. If no support was advised, the plugin failed. This check is removed, since advertisement of support is not mandatory.

Another improvement is a timeout for the registration. If the server does not answer to a filled in form within 15 seconds (fixed, cannot currently be set externally), a timeout is triggered.

The commits are a bit of a mess and mix different stuff, sorry for that.
