### PR TITLE
fix a bug in strophe.roster plugin, it was breaking the connect function if used with 'route' parameter

### DIFF
--- a/roster/strophe.roster.js
+++ b/roster/strophe.roster.js
@@ -71,7 +71,7 @@ Strophe.addConnectionPlugin('roster',
             if (oldCallback !== null)
                 oldCallback.apply(this, arguments);
         };
-        conn.connect = function(jid, pass, callback, wait, hold)
+        conn.connect = function(jid, pass, callback, wait, hold, route)
         {
             oldCallback = callback;
             if (typeof jid  == "undefined")
@@ -79,7 +79,7 @@ Strophe.addConnectionPlugin('roster',
             if (typeof pass == "undefined")
                 pass = null;
             callback = newCallback;
-            _connect.apply(conn, [jid, pass, callback, wait, hold]);
+            _connect.apply(conn, [jid, pass, callback, wait, hold, route]);
         };
         conn.attach = function(jid, sid, rid, callback, wait, hold, wind)
         {


### PR DESCRIPTION
 if we were needing a 'route' parameter in our connect function, as the plugin is overriding the connect function, but was not handling that 'route' parameter
