### PR TITLE
Remove irrelevant namespace from message bodies

### DIFF
--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -159,7 +159,7 @@ Strophe.addConnectionPlugin 'muc',
       from: @_connection.jid
       type: type
       id: msgid )
-    .c("body", xmlns: Strophe.NS.CLIENT)
+    .c("body")
     .t(message)
     msg.up()
     if html_message?


### PR DESCRIPTION
Fixes https://github.com/candy-chat/candy/issues/311
