### PR TITLE
Allow 1.x versions of Strophe

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
         "README.markdown"
     ],
     "dependencies": {
-        "strophe": ">=1.1.0"
+        "strophe": ">=1.1"
     }
 }


### PR DESCRIPTION
Avoids conflicts when using both strophejs and strophejs-plugins as Bower dependencies