### PR TITLE
Sends all presence messages to _presence_handlers

### DIFF
--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -74,14 +74,7 @@ Strophe.addConnectionPlugin 'muc',
       if stanza.nodeName is "message"
         handlers = room._message_handlers
       else if stanza.nodeName is "presence"
-        xquery = stanza.getElementsByTagName "x"
-        if xquery.length > 0
-          # Handle only MUC user protocol
-          for x in xquery
-            xmlns = x.getAttribute "xmlns"
-            if xmlns and xmlns.match Strophe.NS.MUC
-              handlers = room._presence_handlers
-              break
+        handlers = room._presence_handlers
 
       # loop over selected handlers (if any) and remove on false
       for id, handler of handlers

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -69,7 +69,7 @@
       if (this._muc_handler == null) {
         this._muc_handler = this._connection.addHandler((function(_this) {
           return function(stanza) {
-            var from, handler, handlers, id, roomname, x, xmlns, xquery, _i, _len;
+            var from, handler, handlers, id, roomname;
             from = stanza.getAttribute('from');
             if (!from) {
               return true;
@@ -83,17 +83,7 @@
             if (stanza.nodeName === "message") {
               handlers = room._message_handlers;
             } else if (stanza.nodeName === "presence") {
-              xquery = stanza.getElementsByTagName("x");
-              if (xquery.length > 0) {
-                for (_i = 0, _len = xquery.length; _i < _len; _i++) {
-                  x = xquery[_i];
-                  xmlns = x.getAttribute("xmlns");
-                  if (xmlns && xmlns.match(Strophe.NS.MUC)) {
-                    handlers = room._presence_handlers;
-                    break;
-                  }
-                }
-              }
+              handlers = room._presence_handlers;
             }
             for (id in handlers) {
               handler = handlers[id];


### PR DESCRIPTION
Currently any presence message that does not have
an ‘x’ tag does not get send to the
presence_handler. This means error messages such
as

`<presence xmlns='jabber:client' type='error' to=‘xx’ from=‘xx/test'>
<error type='cancel'>
  <not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
</error>
</presence>
`
does not get passed to the handler. This results in
errors like this not being handled and client code
not knowing about it and instead assuming
everything is fine.

This commit removes the custom handling and passes
all presence messages to the handlers attached,
which is how the code has always worked in the case
of the message_handlers.

This way error handling can be implemented in the
presence_handlers, as how they are being done in
the message_handlers.
