### PR TITLE
Type attribute on data forms is mandatory

### DIFF
--- a/mam/strophe.mam.v0.3.js
+++ b/mam/strophe.mam.v0.3.js
@@ -30,7 +30,7 @@ Strophe.addConnectionPlugin('mam', {
             mamAttr.queryid = options['queryid'];
             delete options['queryid'];
         }
-        var iq = $iq(attr).c('query', mamAttr).c('x',{xmlns:'jabber:x:data'});
+        var iq = $iq(attr).c('query', mamAttr).c('x',{xmlns:'jabber:x:data', type:'submit'});
 
         iq.c('field',{var:'FORM_TYPE'}).c('value').t('urn:xmpp:mam:0').up().up();
         var i;


### PR DESCRIPTION
As defined in [XEP-0004 Data forms](http://xmpp.org/extensions/xep-0004.html), type attribute on x tag is mandatory.

The example from [XEP-0313](http://xmpp.org/extensions/xep-0313.html#example-6) was fixed in january 2015.