### PR TITLE
Fix missing var statements causing error on strophe.roster.js

### DIFF
--- a/roster/strophe.roster.js
+++ b/roster/strophe.roster.js
@@ -26,6 +26,7 @@ Strophe.addConnectionPlugin('roster',
         this._connection = conn;
         this._callbacks = [];
         this._callbacks_request = [];
+
         /** Property: items
          * Roster items
          * [
@@ -45,12 +46,14 @@ Strophe.addConnectionPlugin('roster',
          *    }
          * ]
          */
-        items = [];
-              /** Property: ver
-               * current roster revision
-               * always null if server doesn't support xep 237
-               */
-        ver = null;
+        var items = [];
+
+        /** Property: ver
+         * current roster revision
+         * always null if server doesn't support xep 237
+         */
+        var ver = null;
+
         // Override the connect and attach methods to always add presence and roster handlers.
         // They are removed when the connection disconnects, so must be added on connection.
         var oldCallback, roster = this, _connect = conn.connect, _attach = conn.attach;


### PR DESCRIPTION
Hey!

I'm was getting the following errors on the file `strophe.roster.js` and I could solve them by just adding `var` statements.

<img width="663" alt="screen shot 2015-08-13 at 10 53 14 pm" src="https://cloud.githubusercontent.com/assets/1904314/9268369/b69b45ce-4234-11e5-8c43-7049fa90c3dc.png">


<img width="674" alt="screen shot 2015-08-13 at 10 54 33 pm" src="https://cloud.githubusercontent.com/assets/1904314/9268370/b69bbad6-4234-11e5-9473-1236d007665b.png">