### PR TITLE
Pass error code and name along from MUC errors

### DIFF
--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -790,6 +790,9 @@ class XmppRoom
     data.states = []
     for c in pres.childNodes
       switch c.nodeName
+        when "error"
+          data.errorcode = c.getAttribute("code")
+          data.error = c.childNodes[0]?.nodeName
         when "status"
           data.status = c.textContent or null
         when "show"

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -968,6 +968,10 @@ XmppRoom = (function() {
     for (i = 0, len = ref.length; i < len; i++) {
       c = ref[i];
       switch (c.nodeName) {
+        case "error":
+          data.errorcode = c.getAttribute("code");
+          data.error = (ref1 = c.childNodes[0]) != null ? ref1.nodeName : undefined;
+          break;
         case "status":
           data.status = c.textContent || null;
           break;


### PR DESCRIPTION
We noticed that error information was not being passed along to the presence handler when trying to join rooms. This resolves that issue. I was not able to actually use the coffee-script compiler to generate identical output for the JS, so I just modified the JS manually. 