### PR TITLE
Fixed instance where items are null and exception is thrown if the ro…

### DIFF
--- a/roster/strophe.roster.js
+++ b/roster/strophe.roster.js
@@ -160,13 +160,16 @@ Strophe.addConnectionPlugin('roster',
      */
     findItem : function(jid)
     {
-        for (var i = 0; i < this.items.length; i++)
-        {
-            if (this.items[i] && this.items[i].jid == jid)
-            {
-                return this.items[i];
-            }
-        }
+        if(this.items)
+	{
+          for (var i = 0; i < this.items.length; i++)
+          {
+              if (this.items[i] && this.items[i].jid == jid)
+              {
+                  return this.items[i];
+              }
+          }
+	}
         return false;
     },
     /** Function: removeItem


### PR DESCRIPTION
This handles the case where the error:  "TypeError: this.items is undefined" is thrown when roster.get has not yet been called.   This can happen if a user is storing the roster in session and restoring from there instead of pull roster.get again.  Either way, it should not be iterating over an array that could potentially be undefined.