### PR TITLE
XEP-198 Stanza Acks

### DIFF
--- a/stream-management/README.md
+++ b/stream-management/README.md
@@ -4,10 +4,10 @@ Strophe.stream-management.js is a plugin that implements stream management on XM
 
 ## Usage
 
-After you connected sucessfully to the XMPP server you can enable stream management:
+After you connected successfully to the XMPP server you can enable stream management:
 
 ```
-    connection.streamManagement.enable();
+	connection.streamManagement.enable();
 ```
 
 
@@ -21,19 +21,27 @@ By default the client will request a response every 5 stanzas sent. You can chan
 setting the value of requestResponseInterval. To disable this feature set to zero.
 
 ```
-    connection.streamManagement.requestResponseInterval = 5;
+	connection.streamManagement.requestResponseInterval = 5;
 ```
 
 You may also manually request an acknowledgement at any point:
 
 ```
-    connection.streamManagement.requestAcknowledgement();
+	connection.streamManagement.requestAcknowledgement();
 ```
 
 By adding a listener, you will receive the ID of each sent stanza that has been acknowledged by the server.
+There is currently no way remove a listener.
 
 ```
-    connection.streamManagement.addAcknowledgedStanzaListener(myFunc(id))
+	connection.streamManagement.addAcknowledgedStanzaListener(myFunc(id));
+```
+
+The default behavior is to return only the stanza ID.
+You can request that the whole stanza is instead returned.
+
+```
+	connection.streamManagement.returnWholeStanza = true;
 ```
 
 To get sent stanzas stream count use:

--- a/stream-management/README.md
+++ b/stream-management/README.md
@@ -24,6 +24,17 @@ setting the value of requestResponseInterval. To disable this feature set to zer
     connection.streamManagement.requestResponseInterval = 5;
 ```
 
+You may also manually request an acknowledgement at any point:
+
+```
+    connection.streamManagement.requestAcknowledgement();
+```
+
+By adding a listener, you will receive the ID of each sent stanza that has been acknowledged by the server.
+
+```
+    connection.streamManagement.addAcknowledgedStanzaListener(myFunc(id))
+```
 
 To get sent stanzas stream count use:
 
@@ -37,10 +48,27 @@ To get received stream count use:
 	connection.streamManagement.getIncomingCounter();
 ```
 
+You may enable logging to have the console notify you when the server has acknowledged some but not all stanzas.
+Such instances can occur due to transmission delay and is therefore not necessarily a critical error.
+Logging is disabled by default.
+
+```
+	connection.streamManagement.logging = true;
+```
+
+# Notes
+
+Please note that between requesting the enablement of stream management and the server confirming support.
+The sending stream is paused. This means that if the server does not support XEP-198, your application
+will stop sending stanzas until to you manually resume the stream 'connection.resume()'.
+
+You may also run into issues if you use 'connection.pause()' or 'connection.resume' elsewhere in your codebase.
+
 ## Contributors
 
 - Tom Evans
 - Javier Vega
+- Emmet McPoland
 
 
 ##TODO

--- a/stream-management/strophe.stream-management.js
+++ b/stream-management/strophe.stream-management.js
@@ -213,13 +213,11 @@ Strophe.addConnectionPlugin('streamManagement', {
 				var delta = reportedHandledCount - lastKnownHandledCount;
 
 				if (delta < 0) {
-					console.error('New reported stanza count lower than previous. New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
-					// throw new Error('New reported stanza count lower than previous. New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
+					this._throwError('New reported stanza count lower than previous. New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
 				}
 
 				if (delta > this._unacknowledgedStanzas.length) {
-					console.error('Higher reported acknowledge count than unacknowledged stanzas. Reported Acknowledge Count: ' + delta + ' - Unacknowledge Stanza Count: ' + this._unacknowledgedStanzas.length + ' - New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
-					// throw new Error('Higher reported acknowledge count than unacknowledged stanzas. Reported Acknowledge Count: ' + delta + ' - Unacknowledge Stanza Count: ' + this._unacknowledgedStanzas.length + ' - New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
+					this._throwError('Higher reported acknowledge count than unacknowledged stanzas. Reported Acknowledge Count: ' + delta + ' - Unacknowledge Stanza Count: ' + this._unacknowledgedStanzas.length + ' - New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
 				}
 
 				for(var i = 0; i < delta; i++) {
@@ -268,6 +266,11 @@ Strophe.addConnectionPlugin('streamManagement', {
         if (this._isStreamManagementEnabled) {
             this._clientProcessedStanzasCounter++;
         }
-    }
+    },
+
+		_throwError(msg) {
+			console.error(msg);
+			throw new Error(msg);
+		}
 
 });

--- a/stream-management/strophe.stream-management.js
+++ b/stream-management/strophe.stream-management.js
@@ -143,6 +143,11 @@ Strophe.addConnectionPlugin('streamManagement', {
         }
     },
 
+		requestAcknowledgement: function() {
+				this._requestResponseIntervalCount = 0;
+				this._c.send($build('r', { xmlns: this._NS }));
+    },
+
     enable: function() {
         this._c.send($build('enable', {xmlns: this._NS, resume: false}));
 				this._c.flush();
@@ -253,8 +258,7 @@ Strophe.addConnectionPlugin('streamManagement', {
                 this._requestResponseIntervalCount++;
 
                 if (this._requestResponseIntervalCount === this.requestResponseInterval) {
-                    this._requestResponseIntervalCount = 0;
-										this._c.send($build('r', { xmlns: this._NS }));
+                    this.requestAcknowledgement();
                 }
             }
         }

--- a/stream-management/strophe.stream-management.js
+++ b/stream-management/strophe.stream-management.js
@@ -236,7 +236,7 @@ Strophe.addConnectionPlugin('streamManagement', {
 		}
 
 		if (this.logging && this._unacknowledgedStanzas.length > 0) {
-			console.warn('Unacknowledged stanzas. Unacknowledged Count: ' + delta);
+			console.warn('Unacknowledged stanzas', this._unacknowledgedStanzas);
 		}
 	},
 

--- a/stream-management/strophe.stream-management.js
+++ b/stream-management/strophe.stream-management.js
@@ -17,6 +17,11 @@ Strophe.addConnectionPlugin('streamManagement', {
 	logging: true,
 
 	/**
+	* @property {Boolean} returnWholeStanza: Set to true to return the acknowledged stanzas, otherwise only return its ID.
+	*/
+	returnWholeStanza: false,
+
+	/**
 	* @property {Boolean} autoSendCountOnEveryIncomingStanza: Set to true to send an 'a' response after every stanza.
 	* @default false
 	* @public
@@ -180,10 +185,7 @@ Strophe.addConnectionPlugin('streamManagement', {
 			if (Strophe.isTagEqual(child, 'iq') ||
 			Strophe.isTagEqual(child, 'presence') ||
 			Strophe.isTagEqual(child, 'message')) {
-				if (this._isStreamManagementEnabled) {
-					this._unacknowledgedStanzas.push(child.getAttribute('id'));
-				}
-				this._increaseSentStanzasCounter();
+				this._increaseSentStanzasCounter(child);
 			}
 		}
 
@@ -251,8 +253,9 @@ Strophe.addConnectionPlugin('streamManagement', {
 		}
 	},
 
-	_increaseSentStanzasCounter: function() {
+	_increaseSentStanzasCounter: function(elem) {
 		if (this._isStreamManagementEnabled) {
+			this._unacknowledgedStanzas.push(this.returnWholeStanza ? elem : elem.getAttribute('id'));
 
 			this._clientSentStanzasCounter++;
 

--- a/stream-management/strophe.stream-management.js
+++ b/stream-management/strophe.stream-management.js
@@ -254,9 +254,7 @@ Strophe.addConnectionPlugin('streamManagement', {
 
                 if (this._requestResponseIntervalCount === this.requestResponseInterval) {
                     this._requestResponseIntervalCount = 0;
-                    setTimeout(function(){
-                        this._c.send($build('r', { xmlns: this._NS }));
-                    }.bind(this), 100);
+										this._c.send($build('r', { xmlns: this._NS }));
                 }
             }
         }

--- a/stream-management/strophe.stream-management.js
+++ b/stream-management/strophe.stream-management.js
@@ -1,276 +1,276 @@
 
 /**
- * StropheJS - Stream Management XEP-0198
- *
- * This plugin implements stream mangemament ACK capabilities of the specs XEP-0198.
- * Note: Resumption is not supported in this current implementation.
- *
- * Reference: http://xmpp.org/extensions/xep-0198.html
- *
- * @class streamManagement
- */
+* StropheJS - Stream Management XEP-0198
+*
+* This plugin implements stream mangemament ACK capabilities of the specs XEP-0198.
+* Note: Resumption is not supported in this current implementation.
+*
+* Reference: http://xmpp.org/extensions/xep-0198.html
+*
+* @class streamManagement
+*/
 Strophe.addConnectionPlugin('streamManagement', {
 
-		/**
-		 * @property {Boolean} logging: Set to true to enable logging regarding out of sync stanzas.
-		 */
-		logging: true,
+	/**
+	* @property {Boolean} logging: Set to true to enable logging regarding out of sync stanzas.
+	*/
+	logging: true,
 
-    /**
-     * @property {Boolean} autoSendCountOnEveryIncomingStanza: Set to true to send an 'a' response after every stanza.
-     * @default false
-     * @public
-     */
-    autoSendCountOnEveryIncomingStanza: false,
+	/**
+	* @property {Boolean} autoSendCountOnEveryIncomingStanza: Set to true to send an 'a' response after every stanza.
+	* @default false
+	* @public
+	*/
+	autoSendCountOnEveryIncomingStanza: false,
 
-    /**
-     * @property {Integer} requestResponseInterval: Set this value to send a request for counter on very interval
-     * number of stanzas sent. Set to 0 to disable.
-     * @default 5
-     * @public
-     */
-    requestResponseInterval: 5,
+	/**
+	* @property {Integer} requestResponseInterval: Set this value to send a request for counter on very interval
+	* number of stanzas sent. Set to 0 to disable.
+	* @default 5
+	* @public
+	*/
+	requestResponseInterval: 5,
 
-		/**
-     * @property {Function} processAcknowledgedStanza: Callback for each stanza acknowledged by the server.
-		 * Provides the packet id of the stanza as a parameter.
-     * @public
-     */
-    _acknowledgedStanzaListeners: [],
+	/**
+	* @property {Function} processAcknowledgedStanza: Callback for each stanza acknowledged by the server.
+	* Provides the packet id of the stanza as a parameter.
+	* @public
+	*/
+	_acknowledgedStanzaListeners: [],
 
-    /**
-     * @property {Pointer} _c: Strophe connection instance.
-     * @private
-     */
-    _c: null,
+	/**
+	* @property {Pointer} _c: Strophe connection instance.
+	* @private
+	*/
+	_c: null,
 
-    /**
-     * @property {String} _NS XMPP Namespace.
-     * @private
-     */
-    _NS: 'urn:xmpp:sm:3',
+	/**
+	* @property {String} _NS XMPP Namespace.
+	* @private
+	*/
+	_NS: 'urn:xmpp:sm:3',
 
-    /**
-     * @property {Boolean} _isStreamManagementEnabled
-     * @private
-     */
-    _isStreamManagementEnabled: false,
+	/**
+	* @property {Boolean} _isStreamManagementEnabled
+	* @private
+	*/
+	_isStreamManagementEnabled: false,
 
-    /**
-     * @property {Integer} _serverProcesssedStanzasCounter: Keeps count of stanzas confirmed processed by the server.
-     * The server is the source of truth of this value. It is the 'h' attribute on the latest 'a' element received
-     * from the server.
-     * @private
-     */
-    _serverProcesssedStanzasCounter: null,
+	/**
+	* @property {Integer} _serverProcesssedStanzasCounter: Keeps count of stanzas confirmed processed by the server.
+	* The server is the source of truth of this value. It is the 'h' attribute on the latest 'a' element received
+	* from the server.
+	* @private
+	*/
+	_serverProcesssedStanzasCounter: null,
 
-    /**
-     * @property {Integer} _clientProcessedStanzasCounter: Counter of stanzas received by the client from the server.
-     * Client is the source of truth of this value. It is the 'h' attribute in the 'a' sent from the client to
-     * the server.
-     * @private
-     */
-    _clientProcessedStanzasCounter: null,
+	/**
+	* @property {Integer} _clientProcessedStanzasCounter: Counter of stanzas received by the client from the server.
+	* Client is the source of truth of this value. It is the 'h' attribute in the 'a' sent from the client to
+	* the server.
+	* @private
+	*/
+	_clientProcessedStanzasCounter: null,
 
-    /**
-     * @property {Integer} _clientSentStanzasCounter
-     * @private
-     */
-    _clientSentStanzasCounter: null,
+	/**
+	* @property {Integer} _clientSentStanzasCounter
+	* @private
+	*/
+	_clientSentStanzasCounter: null,
 
-    /**
-     * Stores a reference to Strophe connection send function to wrap counting functionality.
-     * @method _originalSend
-     * @type {Handler}
-     * @private
-     */
-    _originalXMLOutput: null,
+	/**
+	* Stores a reference to Strophe connection send function to wrap counting functionality.
+	* @method _originalSend
+	* @type {Handler}
+	* @private
+	*/
+	_originalXMLOutput: null,
 
-    /**
-     * @property {Handler} _requestHandler: Stores reference to handler that process count request from server.
-     * @private
-     */
-    _requestHandler: null,
+	/**
+	* @property {Handler} _requestHandler: Stores reference to handler that process count request from server.
+	* @private
+	*/
+	_requestHandler: null,
 
-    /**
-     * @property {Handler} _incomingHanlder: Stores reference to hanlder that processes incoming stanzas count.
-     * @private
-     */
-    _incomingHandler: null,
+	/**
+	* @property {Handler} _incomingHanlder: Stores reference to hanlder that processes incoming stanzas count.
+	* @private
+	*/
+	_incomingHandler: null,
 
-    /**
-     * @property {Integer} _requestResponseIntervalCount: Counts sent stanzas since last response request.
-     */
-    _requestResponseIntervalCount: 0,
+	/**
+	* @property {Integer} _requestResponseIntervalCount: Counts sent stanzas since last response request.
+	*/
+	_requestResponseIntervalCount: 0,
 
-		/**
-		 * @property {Queue} _unacknowledgedStanzas: Maintains a list of packet ids for stanzas which have yet to be acknowledged.
-		 */
-		_unacknowledgedStanzas: [],
+	/**
+	* @property {Queue} _unacknowledgedStanzas: Maintains a list of packet ids for stanzas which have yet to be acknowledged.
+	*/
+	_unacknowledgedStanzas: [],
 
-    init: function(conn) {
-        this._c = conn;
-        Strophe.addNamespace('SM', this._NS);
+	init: function(conn) {
+		this._c = conn;
+		Strophe.addNamespace('SM', this._NS);
 
-        // Storing origina xmlOutput function to use additional logic
-        this._originalXMLOutput = this._c.xmlOutput;
-        this._c.xmlOutput = this.xmlOutput.bind(this);
-    },
+		// Storing origina xmlOutput function to use additional logic
+		this._originalXMLOutput = this._c.xmlOutput;
+		this._c.xmlOutput = this.xmlOutput.bind(this);
+	},
 
-    statusChanged: function (status) {
-        if (status === Strophe.Status.CONNECTED || status === Strophe.Status.DISCONNECTED) {
+	statusChanged: function (status) {
+		if (status === Strophe.Status.CONNECTED || status === Strophe.Status.DISCONNECTED) {
 
-            this._serverProcesssedStanzasCounter = 0;
-            this._clientProcessedStanzasCounter = 0;
+			this._serverProcesssedStanzasCounter = 0;
+			this._clientProcessedStanzasCounter = 0;
 
-            this._clientSentStanzasCounter = 0;
+			this._clientSentStanzasCounter = 0;
 
-            this._isStreamManagementEnabled = false;
-            this._requestResponseIntervalCount = 0;
+			this._isStreamManagementEnabled = false;
+			this._requestResponseIntervalCount = 0;
 
-						this._unacknowledgedStanzas = [];
+			this._unacknowledgedStanzas = [];
 
-            if (this._requestHandler) {
-                this._c.deleteHandler(this._requestHandler);
-            }
+			if (this._requestHandler) {
+				this._c.deleteHandler(this._requestHandler);
+			}
 
-            if (this._incomingHandler) {
-                this._c.deleteHandler(this._incomingHandler);
-            }
+			if (this._incomingHandler) {
+				this._c.deleteHandler(this._incomingHandler);
+			}
 
-            this._requestHandler = this._c.addHandler(this._handleServerRequestHandler.bind(this), this._NS, 'r');
-            this._incomingHandler = this._c.addHandler(this._incomingStanzaHandler.bind(this));
-        }
-    },
-
-		requestAcknowledgement: function() {
-				this._requestResponseIntervalCount = 0;
-				this._c.send($build('r', { xmlns: this._NS }));
-    },
-
-    enable: function() {
-        this._c.send($build('enable', {xmlns: this._NS, resume: false}));
-				this._c.flush();
-				this._c.pause();
-    },
-
-		addAcknowledgedStanzaListener(listener) {
-			this._acknowledgedStanzaListeners.push(listener);
-		},
-
-    /**
-     * This method overrides the send method implemented by Strophe.Connection
-     * to count outgoing stanzas
-     *
-     * @method Send
-     * @public
-     */
-    xmlOutput: function(elem) {
-				var child;
-				for (var i = 0; i < elem.children.length; i++) {
-					child = elem.children[i];
-	        if (Strophe.isTagEqual(child, 'iq') ||
-	            Strophe.isTagEqual(child, 'presence') ||
-							Strophe.isTagEqual(child, 'message')) {
-							if (this._isStreamManagementEnabled) {
-								this._unacknowledgedStanzas.push(child.getAttribute('id'));
-							}
-	            this._increaseSentStanzasCounter();
-	        }
-				}
-
-        return this._originalXMLOutput.call(this._c, elem);
-    },
-
-    _incomingStanzaHandler: function(elem) {
-        if (Strophe.isTagEqual(elem, 'enabled') && elem.getAttribute('xmlns') === this._NS) {
-            this._isStreamManagementEnabled = true;
-						this._c.resume();
-        }
-
-        if (Strophe.isTagEqual(elem, 'iq') || Strophe.isTagEqual(elem, 'presence') || Strophe.isTagEqual(elem, 'message'))  {
-            this._increaseReceivedStanzasCounter();
-
-            if (this.autoSendCountOnEveryIncomingStanza) {
-                this._answerProcessedStanzas();
-            }
-        }
-
-        if (Strophe.isTagEqual(elem, 'a')) {
-            var handledCount = parseInt(elem.getAttribute('h'));
-						this._handleAcknowledgedStanzas(handledCount, this._serverProcesssedStanzasCounter);
-						this._serverProcesssedStanzasCounter = handledCount;
-
-						if (this.requestResponseInterval > 0) {
-							this._requestResponseIntervalCount = 0;
-						}
-        }
-
-        return true;
-    },
-
-		_handleAcknowledgedStanzas: function(reportedHandledCount, lastKnownHandledCount) {
-				var delta = reportedHandledCount - lastKnownHandledCount;
-
-				if (delta < 0) {
-					this._throwError('New reported stanza count lower than previous. New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
-				}
-
-				if (delta > this._unacknowledgedStanzas.length) {
-					this._throwError('Higher reported acknowledge count than unacknowledged stanzas. Reported Acknowledge Count: ' + delta + ' - Unacknowledge Stanza Count: ' + this._unacknowledgedStanzas.length + ' - New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
-				}
-
-				for(var i = 0; i < delta; i++) {
-					var stanza = this._unacknowledgedStanzas.shift();
-					for (var j = 0; j < this._acknowledgedStanzaListeners.length; j++) {
-						this._acknowledgedStanzaListeners[j](stanza);
-					}
-				}
-
-				if (this.logging && this._unacknowledgedStanzas.length > 0) {
-					console.warn('Unacknowledged stanzas. Unacknowledged Count: ' + delta);
-				}
-    },
-
-    getClientSentStanzasCounter: function() {
-        return this._clientSentStanzasCounter;
-    },
-
-    _handleServerRequestHandler: function() {
-        this._answerProcessedStanzas();
-        return true;
-    },
-
-    _answerProcessedStanzas: function() {
-        if (this._isStreamManagementEnabled) {
-            this._c.send($build('a', { xmlns: this._NS, h: this._clientProcessedStanzasCounter }));
-        }
-    },
-
-    _increaseSentStanzasCounter: function() {
-        if (this._isStreamManagementEnabled) {
-
-            this._clientSentStanzasCounter++;
-
-            if (this.requestResponseInterval > 0) {
-                this._requestResponseIntervalCount++;
-
-                if (this._requestResponseIntervalCount === this.requestResponseInterval) {
-                    this.requestAcknowledgement();
-                }
-            }
-        }
-    },
-
-    _increaseReceivedStanzasCounter: function() {
-        if (this._isStreamManagementEnabled) {
-            this._clientProcessedStanzasCounter++;
-        }
-    },
-
-		_throwError(msg) {
-			console.error(msg);
-			throw new Error(msg);
+			this._requestHandler = this._c.addHandler(this._handleServerRequestHandler.bind(this), this._NS, 'r');
+			this._incomingHandler = this._c.addHandler(this._incomingStanzaHandler.bind(this));
 		}
+	},
+
+	requestAcknowledgement: function() {
+		this._requestResponseIntervalCount = 0;
+		this._c.send($build('r', { xmlns: this._NS }));
+	},
+
+	enable: function() {
+		this._c.send($build('enable', {xmlns: this._NS, resume: false}));
+		this._c.flush();
+		this._c.pause();
+	},
+
+	addAcknowledgedStanzaListener(listener) {
+		this._acknowledgedStanzaListeners.push(listener);
+	},
+
+	/**
+	* This method overrides the send method implemented by Strophe.Connection
+	* to count outgoing stanzas
+	*
+	* @method Send
+	* @public
+	*/
+	xmlOutput: function(elem) {
+		var child;
+		for (var i = 0; i < elem.children.length; i++) {
+			child = elem.children[i];
+			if (Strophe.isTagEqual(child, 'iq') ||
+			Strophe.isTagEqual(child, 'presence') ||
+			Strophe.isTagEqual(child, 'message')) {
+				if (this._isStreamManagementEnabled) {
+					this._unacknowledgedStanzas.push(child.getAttribute('id'));
+				}
+				this._increaseSentStanzasCounter();
+			}
+		}
+
+		return this._originalXMLOutput.call(this._c, elem);
+	},
+
+	_incomingStanzaHandler: function(elem) {
+		if (Strophe.isTagEqual(elem, 'enabled') && elem.getAttribute('xmlns') === this._NS) {
+			this._isStreamManagementEnabled = true;
+			this._c.resume();
+		}
+
+		if (Strophe.isTagEqual(elem, 'iq') || Strophe.isTagEqual(elem, 'presence') || Strophe.isTagEqual(elem, 'message'))  {
+			this._increaseReceivedStanzasCounter();
+
+			if (this.autoSendCountOnEveryIncomingStanza) {
+				this._answerProcessedStanzas();
+			}
+		}
+
+		if (Strophe.isTagEqual(elem, 'a')) {
+			var handledCount = parseInt(elem.getAttribute('h'));
+			this._handleAcknowledgedStanzas(handledCount, this._serverProcesssedStanzasCounter);
+			this._serverProcesssedStanzasCounter = handledCount;
+
+			if (this.requestResponseInterval > 0) {
+				this._requestResponseIntervalCount = 0;
+			}
+		}
+
+		return true;
+	},
+
+	_handleAcknowledgedStanzas: function(reportedHandledCount, lastKnownHandledCount) {
+		var delta = reportedHandledCount - lastKnownHandledCount;
+
+		if (delta < 0) {
+			this._throwError('New reported stanza count lower than previous. New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
+		}
+
+		if (delta > this._unacknowledgedStanzas.length) {
+			this._throwError('Higher reported acknowledge count than unacknowledged stanzas. Reported Acknowledge Count: ' + delta + ' - Unacknowledge Stanza Count: ' + this._unacknowledgedStanzas.length + ' - New: ' + reportedHandledCount + ' - Previous: ' + lastKnownHandledCount);
+		}
+
+		for(var i = 0; i < delta; i++) {
+			var stanza = this._unacknowledgedStanzas.shift();
+			for (var j = 0; j < this._acknowledgedStanzaListeners.length; j++) {
+				this._acknowledgedStanzaListeners[j](stanza);
+			}
+		}
+
+		if (this.logging && this._unacknowledgedStanzas.length > 0) {
+			console.warn('Unacknowledged stanzas. Unacknowledged Count: ' + delta);
+		}
+	},
+
+	getClientSentStanzasCounter: function() {
+		return this._clientSentStanzasCounter;
+	},
+
+	_handleServerRequestHandler: function() {
+		this._answerProcessedStanzas();
+		return true;
+	},
+
+	_answerProcessedStanzas: function() {
+		if (this._isStreamManagementEnabled) {
+			this._c.send($build('a', { xmlns: this._NS, h: this._clientProcessedStanzasCounter }));
+		}
+	},
+
+	_increaseSentStanzasCounter: function() {
+		if (this._isStreamManagementEnabled) {
+
+			this._clientSentStanzasCounter++;
+
+			if (this.requestResponseInterval > 0) {
+				this._requestResponseIntervalCount++;
+
+				if (this._requestResponseIntervalCount === this.requestResponseInterval) {
+					this.requestAcknowledgement();
+				}
+			}
+		}
+	},
+
+	_increaseReceivedStanzasCounter: function() {
+		if (this._isStreamManagementEnabled) {
+			this._clientProcessedStanzasCounter++;
+		}
+	},
+
+	_throwError(msg) {
+		console.error(msg);
+		throw new Error(msg);
+	}
 
 });

--- a/stream-management/strophe.stream-management.js
+++ b/stream-management/strophe.stream-management.js
@@ -123,15 +123,19 @@ Strophe.addConnectionPlugin('streamManagement', {
 		this._c.send($build('r', { xmlns: this._NS }));
 	},
 
-	getClientSentStanzasCounter: function() {
+	getOutgoingCounter: function() {
 		return this._clientSentStanzasCounter;
+	},
+
+	getIncomingCounter: function() {
+		return this._clientProcessedStanzasCounter;
 	},
 
 	init: function(conn) {
 		this._c = conn;
 		Strophe.addNamespace('SM', this._NS);
 
-		// Storing origina xmlOutput function to use additional logic
+		// Storing original xmlOutput function to use additional logic
 		this._originalXMLOutput = this._c.xmlOutput;
 		this._c.xmlOutput = this.xmlOutput.bind(this);
 	},


### PR DESCRIPTION
Added the ability to return the stanza or stanza ID that had been acknowledged by the server. Implementation is based off SMACK (and xmppframework).

https://github.com/igniterealtime/Smack/blob/9a16f684335c887fc77e8e026e78cca01bf6bf27/smack-tcp/src/main/java/org/jivesoftware/smack/sm/SMUtils.java#L49
https://github.com/igniterealtime/Smack/blob/b558a128c3dbcebfe6de5406baf222d6a112c425/smack-tcp/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java#L1820

Also corrected a critical issue which was caused by Strophe sending a presence stanza between sending the enable stanza and receiving the confirmation that it was enabled. The presence stanza had to be counted. As a result the count was always off.

I could have simply set it has having been enabled when we requested it, or set it to a pending state. Instead I thought it might be better to pause the stream until its confirmed that stream management had been enabled.

Also moved to using xmlOutput over send as:
1: The same type object is always passed down. There were several scenarios (including the initial presence), in which isTagEqual failed.
2: If we are to pause and resume the stream, we need to do the counting in xmlOutput, as send is called even when pause has been called.

The only issue with this is that the request stanza wont be bundled.

You can now manually request an acknowledgement, if theres only certain stanzas you really care about (Although all stanzas since the last acknowledgement will still be acknowledged).

Also now throwing errors as well as logging them, incase you want to catch them by overriding Strophes error handing.

Only thing Im semi-weary about is the timeout function I removed, I wasn't sure of its purpose.